### PR TITLE
Add terraform init to deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,9 @@ if ! az account show > /dev/null 2>&1; then
     exit 1
 fi
 
+# Initialize Terraform
+terraform init
+
 # Create a Terraform plan
 terraform plan -out main.tfplan
 


### PR DESCRIPTION
## Purpose
The deployment script does not contain a ```terraform init``` command to initialize the directory prior to running the ```terraform plan`` command, resulting in errors during execution. This pull request adds the ```terraform init``` command to the deployment script to ensure the directory is initialized before running the ```terraform plan``` command. 

Users not familiar with Terraform might not be aware that they need to run ```terraform init``` before doing any other Terraform operations.
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
chmod +x ./deploy.sh
./deploy.sh

* Test the code
Run the commands above. 
```
```

## What to Check
Verify that Terraform stands up the AKS cluster and that the KubeRay operator is installed and the Ray job runs to completion. Also verify that the script prints the IP address of the ray-dash service after the training job completes and that following the link in a web browser displays the Ray dashboard.
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->