### PR TITLE
chore: update terraform script to install AKS cluster and kuberay operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Clone the repository to your local machine. Then make sure you have all the prer
 3. Enable execute permissions on the `deploy.sh` script by running `chmod +x deploy.sh`.
 4. Run the `deploy.sh` script by running `./deploy.sh`. This script will deploy the AKS cluster, install the KubeRay operator then submit a training job to run on the AKS cluster.
 
-## Modle tuning with Ray
+## Model tuning with Ray
 
 You can run model tuning jobs easily on Ray cluster with Azure Blob storage. See the steps in [Ray tuning on Azure Blobs](./docs/ray-tuning-on-blobfuse.md)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Clone the repository to your local machine. Then make sure you have all the prer
 
 ## Modle tuning with Ray
 
-YOu can run model tuning jobs easily on Ray cluster with Azure Blob storage. See the steps in [Ray tuning on Azure Blobs](./docs/ray-tuning-on-blobfuse.md)
+You can run model tuning jobs easily on Ray cluster with Azure Blob storage. See the steps in [Ray tuning on Azure Blobs](./docs/ray-tuning-on-blobfuse.md)
 
 ## Resources
 

--- a/docs/ray-tuning-on-blobfuse.md
+++ b/docs/ray-tuning-on-blobfuse.md
@@ -9,33 +9,41 @@ In this article, you will tune the GPT-2 large model using KubeRay, which will s
 
 ### Quickstart
 1. Clone the repository https://github.com/Azure-Samples/aks-ray-sample on to your local machine.
-2. Navigate to the directory you cloned the repository and then navigate to sample-tunning-setup/terraform 
+2. Navigate to the directory you cloned the repository and then navigate to sample-tunning-setup/terraform.
 3. Enable execute permissions on the `deploy.sh` script by running `chmod +x deploy.sh`.
-4. Run the `deploy.sh` script by running `./deploy.sh`. This script will deploy the AKS cluster, install the KubeRay operator then submit a training job pointing to azure blob storage to run on the AKS cluster
+4. Run the `deploy.sh` script by running `./deploy.sh`. This script will deploy the AKS cluster, install the KubeRay operator then submit a training job pointing to azure blob storage to run on the AKS cluster.
 
    Once the script finish execution, then open the URL displayed in the final line (see the example below for the script's last few lines).
    ```sh
-   Current Kubernetes Context: cluster-raydemo-z5kmlg
+   ...
+   ...
+   ...
+   Merged "cluster-raydemo-gzumb2" as current context in /home/mittas/.kube/config
+   Current Kubernetes Context: cluster-raydemo-gzumb2
    NAME                                 STATUS   ROLES    AGE     VERSION
-   aks-nodepool1-17652229-vmss000000    Ready    <none>   2m10s   v1.32.4
-   aks-nodepool1-17652229-vmss000001    Ready    <none>   2m43s   v1.32.4
-   aks-nodepool1-17652229-vmss000002    Ready    <none>   2m14s   v1.32.4
-   aks-nodepool1-17652229-vmss000003    Ready    <none>   2m40s   v1.32.4
-   aks-nodepool1-17652229-vmss000004    Ready    <none>   2m39s   v1.32.4
-   aks-nodepool1-17652229-vmss000005    Ready    <none>   2m42s   v1.32.4
-   aks-systempool-69094345-vmss000000   Ready    <none>   9m37s   v1.32.4
+   aks-nodepool1-13403768-vmss000000    Ready    <none>   3m4s    v1.32.4
+   aks-nodepool1-13403768-vmss000001    Ready    <none>   2m40s   v1.32.4
+   aks-nodepool1-13403768-vmss000002    Ready    <none>   2m39s   v1.32.4
+   aks-nodepool1-13403768-vmss000003    Ready    <none>   3m9s    v1.32.4
+   aks-nodepool1-13403768-vmss000004    Ready    <none>   2m46s   v1.32.4
+   aks-nodepool1-13403768-vmss000005    Ready    <none>   2m42s   v1.32.4
+   aks-systempool-37389976-vmss000000   Ready    <none>   10m     v1.32.4
    NAME                                                         READY   STATUS              RESTARTS   AGE
-   ingress-nginx-controller-68547f7c99-cvk7n                    1/1     Running             0          61s
-   kuberay-operator-b568bb49f-8splk                             1/1     Running             0          81s
-   rayjob-tune-gpt2-raycluster-7qp9g-head-bvzpl                 0/1     ContainerCreating   0          34s
-   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-d7pvs   0/1     Init:0/2            0          34s
-   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-jgzn9   0/1     Init:0/2            0          34s
-   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-nr2dq   0/1     Init:0/2            0          34s
-   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-r9z5m   0/1     Init:0/2            0          34s
-   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-wbb8j   0/1     Init:0/2            0          34s
-   Status: Running
-   Job Status: Complete
+   ingress-nginx-controller-68547f7c99-hzl6t                    1/1     Running             0          75s
+   kuberay-operator-b568bb49f-nd9qn                             1/1     Running             0          97s
+   rayjob-tune-gpt2-raycluster-bd7lt-head-kg4vl                 0/1     ContainerCreating   0          46s
+   rayjob-tune-gpt2-raycluster-bd7lt-large-group-worker-b7nfh   0/1     Init:0/2            0          46s
+   rayjob-tune-gpt2-raycluster-bd7lt-large-group-worker-lgd2m   0/1     Init:0/2            0          46s
+   rayjob-tune-gpt2-raycluster-bd7lt-large-group-worker-s976k   0/1     Init:0/2            0          46s
+   rayjob-tune-gpt2-raycluster-bd7lt-large-group-worker-t4dg6   0/1     Init:0/2            0          46s
+   rayjob-tune-gpt2-raycluster-bd7lt-large-group-worker-vh4gz   0/1     Init:0/2            0          46s
+   Ray Job Status: Initializing
    service/ray-dash exposed
    ingress.networking.k8s.io/ray-dash created
-   KubeRay Dashboard URL: http://4.236.1.93/
+   KubeRay Dashboard URL(progress of rayjob can be viewed here): http://4.236.5.17/
+   Waiting for Kuberay job completion
+   Job Status: Complete
+   To view the final model and checkpoint files go to Azure portal
+   Navigate through ResourceGroup MC_rg-raydemo-gzumb2_cluster-raydemo-gzumb2_westus3 --> Storage Account of fuse819db34db11346b58ab --> DataStorage --> Container of pvc-38112449-0e97-4b9e-94ff-e70300e2c7a9
    ```
+   Note: The above script utilizes Azure Blob Storage by dynamically provisioning PersistentVolumes. The final model and checkpoint files can be accessed in the designated blob containers.

--- a/docs/ray-tuning-on-blobfuse.md
+++ b/docs/ray-tuning-on-blobfuse.md
@@ -13,7 +13,7 @@ In this article, you will tune the GPT-2 large model using KubeRay, which will s
 3. Enable execute permissions on the `deploy.sh` script by running `chmod +x deploy.sh`.
 4. Run the `deploy.sh` script by running `./deploy.sh`. This script will deploy the AKS cluster, install the KubeRay operator then submit a training job pointing to azure blob storage to run on the AKS cluster.
 
-   Once the script finish execution, then open the URL displayed in the final line (see the example below for the script's last few lines).
+   Once the ray job starts running, open the Dashboard URL as show below to track the progress of the job.
    ```sh
    ...
    ...

--- a/docs/ray-tuning-on-blobfuse.md
+++ b/docs/ray-tuning-on-blobfuse.md
@@ -3,80 +3,39 @@
 In this article, you will tune the GPT-2 large model using KubeRay, which will save the final model and checkpoints to an Azure Blob Storage account.
 
 ## Prerequisites
-An AKS cluster with 10 virtual machines. To create an AKS cluster with 9 Standard_D16d_v5 VMs and 1 Standard_D32d_v5 VM, run the following commands:
-
-```azurecli-interactive
-    az aks create --resource-group myResourceGroup --name myAKSCluster --node-count 9 --node-vm-size Standard_D16d_v5 --generate-ssh-keys
-    az aks nodepool add --resource-group myResourceGroup --cluster-name myAKSCluster --name nodepool2 --node-count 1 --node-vm-size Standard_D32d_v5
-```
-
-## Setup storage for the tuning job
-
-1. Create a Storage Account as described [here](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal).
-
-2. Create a container in that storage account as described [here](https://learn.microsoft.com/en-us/azure/storage/blobs/blob-containers-portal#create-a-container)
-
-3. Enable Azure Blob CSI driver on the AKS cluster as described [here](https://learn.microsoft.com/en-us/azure/aks/azure-blob-csi?tabs=NFS#enable-csi-driver-on-a-new-or-existing-aks-cluster).
-
-4. Mount Azure Blob Storage in AKS using the Blob CSI driver with managed identity. Follow the steps [here](https://github.com/kubernetes-sigs/blob-csi-driver/tree/master/deploy/example/blobfuse-mi#mount-azure-blob-storage-with-managed-identity) to create a Managed Identity and assign the Storage Blob Data Contributor role. 
-
-## Setup the AKS cluster and your local machine
-
-1. Install [KubeRay](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html#step-2-install-kuberay-operator) operator on your AKS cluster.
-
-    ```bash
-    helm repo add kuberay https://ray-project.github.io/kuberay-helm/
-    helm repo update
-    helm install kuberay-operator kuberay/kuberay-operator --version 1.3.0
-    ```
-
-2. Edit the pv.yaml file in the sample-tuning-setup directory, and update the values for RESOURCE_GROUP_NAME, STORAGE_ACCOUNT_NAME, and CONTAINER_NAME.
-
-3. Update the MANAGED_IDENTITY_CLIENT_ID in pv.yaml and storageclass.yaml to the client ID of the Managed Identity that now has access to your storage account. You can find the client ID by navigating to the Azure portal, selecting your Managed Identity, and copying the client ID from the 'Overview' section.
-
-4. Apply all the YAML files located in the sample-tuning-setup directory
-
-    ```bash
-    kubectl apply -f sample-tuning-setup/storageclass.yaml
-    kubectl apply -f sample-tuning-setup/pv.yaml
-    kubectl apply -f sample-tuning-setup/pvc.yaml
-    kubectl apply -f sample-tuning-setup/rayjob.yaml
-    ```
-
-    After a moment, you should be able to see the Ray pods running on the cluster by running the following command:
-
-    ```bash
-    kubectl get pods
-    ```
-
-    This should also start the tuning job in a pod that starts with name "rayjob-tune-gpt2". Example below:
-
-   ![image](https://github.com/user-attachments/assets/a3e97de8-6f84-4976-8697-cd20f78e3274)
+- Install Azure CLI by following [azure-cli](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli-linux?view=azure-cli-latest&pivots=apt) doc.
+- Install terraform command line tool by following [installation](https://developer.hashicorp.com/terraform/install) doc.
 
 
-6. The status of the job can be tracked by tracking the logs of the rayjob-tune-gpt2 pod.
+### Quickstart
+1. Clone the repository https://github.com/Azure-Samples/aks-ray-sample on to your local machine.
+2. Navigate to the directory you cloned the repository and then navigate to sample-tunning-setup/terraform 
+3. Enable execute permissions on the `deploy.sh` script by running `chmod +x deploy.sh`.
+4. Run the `deploy.sh` script by running `./deploy.sh`. This script will deploy the AKS cluster, install the KubeRay operator then submit a training job pointing to azure blob storage to run on the AKS cluster
 
-    ```bash
-    kubectl logs <rayjob_pod_name> -f
-    ```
-
-5. Another way to track the status of the job is from the ray dashboard.
-
-    Find the service name of the ray job using the below command
-
-    ```bash
-    kubectl get services | grep rayjob-tune-gpt2
-    ```
-
-    Open a terminal window and enable port-forwarding for the Ray service to access Ray locally.
-
-    ```bash
-    kubectl port-forward services/<rayjob_service_name> 8265:8265
-    ```
-
-    Open "http://localhost:8265/" in any browser which should load the dashboard for monitoring the ray job.
-
-Once the run is complete, you will find the final model and checkpoint files in your blob container.
-
-
-
+   Once the script finish execution, then open the URL displayed in the final line (see the example below for the script's last few lines).
+   ```sh
+   Current Kubernetes Context: cluster-raydemo-z5kmlg
+   NAME                                 STATUS   ROLES    AGE     VERSION
+   aks-nodepool1-17652229-vmss000000    Ready    <none>   2m10s   v1.32.4
+   aks-nodepool1-17652229-vmss000001    Ready    <none>   2m43s   v1.32.4
+   aks-nodepool1-17652229-vmss000002    Ready    <none>   2m14s   v1.32.4
+   aks-nodepool1-17652229-vmss000003    Ready    <none>   2m40s   v1.32.4
+   aks-nodepool1-17652229-vmss000004    Ready    <none>   2m39s   v1.32.4
+   aks-nodepool1-17652229-vmss000005    Ready    <none>   2m42s   v1.32.4
+   aks-systempool-69094345-vmss000000   Ready    <none>   9m37s   v1.32.4
+   NAME                                                         READY   STATUS              RESTARTS   AGE
+   ingress-nginx-controller-68547f7c99-cvk7n                    1/1     Running             0          61s
+   kuberay-operator-b568bb49f-8splk                             1/1     Running             0          81s
+   rayjob-tune-gpt2-raycluster-7qp9g-head-bvzpl                 0/1     ContainerCreating   0          34s
+   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-d7pvs   0/1     Init:0/2            0          34s
+   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-jgzn9   0/1     Init:0/2            0          34s
+   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-nr2dq   0/1     Init:0/2            0          34s
+   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-r9z5m   0/1     Init:0/2            0          34s
+   rayjob-tune-gpt2-raycluster-7qp9g-large-group-worker-wbb8j   0/1     Init:0/2            0          34s
+   Status: Running
+   Job Status: Complete
+   service/ray-dash exposed
+   ingress.networking.k8s.io/ray-dash created
+   KubeRay Dashboard URL: http://4.236.1.93/
+   ```

--- a/sample-tuning-setup/terraform/deploy.sh
+++ b/sample-tuning-setup/terraform/deploy.sh
@@ -36,7 +36,6 @@ kubectl get nodes
 # Output the pods in the kuberay namespace
 kubectl get pods -n $kuberay_namespace
 
-kuberay_namespace="default"
 # Get the status of the Ray job
 job_status=$(kubectl get rayjobs -n $kuberay_namespace -o jsonpath='{.items[0].status.jobDeploymentStatus}')
 
@@ -91,6 +90,10 @@ EOF
 
 # Now find the public IP address of the ingress controller
 lb_public_ip=$(kubectl get ingress -n $kuberay_namespace -o jsonpath='{.items[?(@.metadata.name == "ray-dash")].status.loadBalancer.ingress[0].ip}')
+while [ -z ${lb_public_ip} ]; do
+	lb_public_ip=$(kubectl get ingress -n $kuberay_namespace -o jsonpath='{.items[?(@.metadata.name == "ray-dash")].status.loadBalancer.ingress[0].ip}')
+	sleep 1
+done
 
 echo "KubeRay Dashboard URL: http://$lb_public_ip/"
 

--- a/sample-tuning-setup/terraform/deploy.sh
+++ b/sample-tuning-setup/terraform/deploy.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Check if the user is logged into Azure CLI
+if ! az account show > /dev/null 2>&1; then
+    echo "Please login to Azure CLI using 'az login' before running this script."
+    exit 1
+fi
+
+# Initialize Terraform
+terraform init
+
+# Create a Terraform plan
+terraform plan -out main.tfplan
+
+# Apply the Terraform plan
+terraform apply main.tfplan
+
+# Retrieve the Terraform outputs and store in variables
+resource_group_name=$(terraform output -raw resource_group_name)
+system_node_pool_name=$(terraform output -raw system_node_pool_name)
+aks_cluster_name=$(terraform output -raw kubernetes_cluster_name)
+kuberay_namespace=$(terraform output -raw kubernetes_rayjob_namespace)
+
+# Get AKS credentials for the cluster
+az aks get-credentials \
+    --resource-group $resource_group_name \
+    --name $aks_cluster_name
+
+# Output the current Kubernetes context
+current_context=$(kubectl config current-context)
+echo "Current Kubernetes Context: $current_context"
+
+# Output the nodes in the cluster
+kubectl get nodes
+
+# Output the pods in the kuberay namespace
+kubectl get pods -n $kuberay_namespace
+
+kuberay_namespace="default"
+# Get the status of the Ray job
+job_status=$(kubectl get rayjobs -n $kuberay_namespace -o jsonpath='{.items[0].status.jobDeploymentStatus}')
+
+# Wait for the Ray job to complete
+while [ "$job_status" != "Complete" ]; do
+    echo -ne "Job Status: $job_status\\r"
+    sleep 30
+    job_status=$(kubectl get rayjobs -n $kuberay_namespace -o jsonpath='{.items[0].status.jobDeploymentStatus}')
+done
+echo "Job Status: $job_status"
+
+# Check if the job succeeded
+job_status=$(kubectl get rayjobs -n $kuberay_namespace -o jsonpath='{.items[0].status.jobStatus}')
+if [ "$job_status" != "SUCCEEDED" ]; then
+    echo "Job Failed!"
+    exit 1
+fi
+
+# If the job succeeded, get the Ray cluster head service
+rayclusterhead=$(kubectl get service -n $kuberay_namespace | grep 'rayjob-tune-gpt2' | grep 'ClusterIP' | awk '{print $1}')
+
+# Now create a service of type NodePort for the Ray cluster head
+kubectl expose service $rayclusterhead \
+-n $kuberay_namespace \
+--port=80 \
+--target-port=8265 \
+--type=NodePort \
+--name=ray-dash
+
+# Create an ingress for the KubeRay dashboard
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ray-dash
+  namespace: $kuberay_namespace
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - backend:
+          service:
+            name: ray-dash
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+EOF
+
+# Now find the public IP address of the ingress controller
+lb_public_ip=$(kubectl get ingress -n $kuberay_namespace -o jsonpath='{.items[?(@.metadata.name == "ray-dash")].status.loadBalancer.ingress[0].ip}')
+
+echo "KubeRay Dashboard URL: http://$lb_public_ip/"
+
+exit 0

--- a/sample-tuning-setup/terraform/outputs.tf
+++ b/sample-tuning-setup/terraform/outputs.tf
@@ -1,0 +1,50 @@
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "kubernetes_cluster_name" {
+  value = azurerm_kubernetes_cluster.aks.name
+}
+
+output "client_certificate" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate
+  sensitive = true
+}
+
+output "cluster_password" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].password
+  sensitive = true
+}
+
+output "cluster_username" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].username
+  sensitive = true
+}
+
+output "host" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].host
+  sensitive = true
+}
+
+output "kube_config" {
+  value     = azurerm_kubernetes_cluster.aks.kube_config_raw
+  sensitive = true
+}
+
+output "system_node_pool_name" {
+  value = azurerm_kubernetes_cluster.aks.default_node_pool[0].name
+}
+
+output "kubernetes_rayjob_namespace" {
+  value = kubernetes_persistent_volume_claim.rayjob_pvc.metadata[0].namespace
+}

--- a/sample-tuning-setup/terraform/providers.tf
+++ b/sample-tuning-setup/terraform/providers.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "~>1.5"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>4.30.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.9.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.11.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  subscription_id = var.subscription_id
+}
+
+# Helm provider uses Kubernetes config loaded by azurerm_kubernetes_cluster
+provider "helm" {
+  kubernetes = {
+    host                   = local.host
+    client_certificate     = local.client_certificate
+    client_key             = local.client_key
+    cluster_ca_certificate = local.cluster_ca_certificate
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.host
+  client_certificate     = local.client_certificate
+  client_key             = local.client_key
+  cluster_ca_certificate = local.cluster_ca_certificate
+}
+
+provider "kubectl" {
+  host                   = local.host
+  client_certificate     = local.client_certificate
+  client_key             = local.client_key
+  cluster_ca_certificate = local.cluster_ca_certificate
+}

--- a/sample-tuning-setup/terraform/ssh.tf
+++ b/sample-tuning-setup/terraform/ssh.tf
@@ -1,0 +1,25 @@
+
+resource "random_pet" "ssh_key_name" {
+  prefix    = "ssh"
+  separator = ""
+}
+
+resource "azapi_resource_action" "ssh_public_key_gen" {
+  type        = "Microsoft.Compute/sshPublicKeys@2022-11-01"
+  resource_id = azapi_resource.ssh_public_key.id
+  action      = "generateKeyPair"
+  method      = "POST"
+
+  response_export_values = ["publicKey", "privateKey"]
+}
+
+resource "azapi_resource" "ssh_public_key" {
+  type      = "Microsoft.Compute/sshPublicKeys@2022-11-01"
+  name      = random_pet.ssh_key_name.id
+  location  = azurerm_resource_group.rg.location
+  parent_id = azurerm_resource_group.rg.id
+}
+
+output "key_data" {
+  value = azapi_resource_action.ssh_public_key_gen.output.publicKey
+}

--- a/sample-tuning-setup/terraform/variables.tf
+++ b/sample-tuning-setup/terraform/variables.tf
@@ -26,29 +26,42 @@ variable "azure_kubernetes_version" {
   type        = string
 }
 
-variable "system_node_pool_vm_size" {
+variable "system_nodepool_vm_size" {
   type        = string
   description = "The size of the Virtual Machine."
   default     = "Standard_D2_v2"
 }
 
-variable "system_node_pool_node_count" {
+variable "system_nodepool_node_count" {
   type        = number
   description = "The initial quantity of nodes for the system node pool."
   default     = 1
 }
 
-variable "ray_node_pool_vm_size" {
+variable "ray_nodepool1_vm_size" {
   type        = string
-  description = "The size of the Virtual Machine."
+  description = "The size of the Virtual Machine of first nodepool."
   default     = "Standard_D16s_v5"
 }
 
 # It is recommended to configure worker node as rayworker count + 1
-variable "ray_node_pool_node_count" {
+variable "ray_nodepool1_node_count" {
   type        = number
   description = "The initial quantity of node for the workload pools."
   default     = 10
+}
+
+# It is recommended to configure second node pool only if required
+variable "ray_nodepool2_vm_size" {
+  type        = string
+  description = "The size of the Virtual Machine of second nodepool."
+  default     = "Standard_D16s_v3"
+}
+
+variable "ray_nodepool2_node_count" {
+  type        = number
+  description = "The initial quantity of node for the workload pools."
+  default     = 0
 }
 
 variable "ray_second_node_pool_vm_size" {

--- a/sample-tuning-setup/terraform/variables.tf
+++ b/sample-tuning-setup/terraform/variables.tf
@@ -1,0 +1,111 @@
+variable "subscription_id" {
+  description = "The Azure subscription ID."
+  type        = string
+}
+
+variable "resource_group_owner" {
+  description = "The owner of the resource group."
+  type        = string
+}
+
+variable "resource_group_location" {
+  type        = string
+  default     = "westus3"
+  description = "Location of the resource group."
+}
+
+variable "project_prefix" {
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+  type        = string
+  default     = "raydemo"
+}
+
+variable "azure_kubernetes_version" {
+  description = "Version of the azure kubernetes"
+  default = "1.32"
+  type        = string
+}
+
+variable "system_node_pool_vm_size" {
+  type        = string
+  description = "The size of the Virtual Machine."
+  default     = "Standard_D2_v2"
+}
+
+variable "system_node_pool_node_count" {
+  type        = number
+  description = "The initial quantity of nodes for the system node pool."
+  default     = 1
+}
+
+variable "ray_node_pool_vm_size" {
+  type        = string
+  description = "The size of the Virtual Machine."
+  default     = "Standard_D16s_v5"
+}
+
+# It is recommended to configure worker node as rayworker count + 1
+variable "ray_node_pool_node_count" {
+  type        = number
+  description = "The initial quantity of node for the workload pools."
+  default     = 10
+}
+
+variable "ray_second_node_pool_vm_size" {
+  type        = string
+  description = "The size of the second set of node pool"
+  default     = "Standard_D16_v3"
+}
+
+variable "ray_second_node_pool_node_count" {
+  type        = number
+  description = "The initial quantity of node for the workload pools."
+  default     = 5
+}
+
+variable "username" {
+  type        = string
+  description = "The admin username for the new cluster."
+  default     = "azureadmin"
+}
+
+variable "azure_storage_profile" {
+  description                    = "Azure CSI drivers storage profile"
+  type                           = map(bool)
+  default                        = {
+    enable_disk_csi_driver       = false
+    enable_file_csi_driver       = false
+    enable_blob_csi_driver       = true
+    enable_snapshot_controller   = false
+  }
+}
+
+variable "kuberay_version" {
+  description                    = "Kuberay version that needs to be installed"
+  type                           = string
+  default                        = "1.3.0"
+}
+
+variable "kuberay_persistent_volume_claim_name" {
+  description  = "Name of kubernetes PersistentVolume Claim to deploy rayjob"
+  type         = string
+  default      = "pvc-blob-results"
+}
+
+variable "kuberay_namespace" {
+  description  = "Namespace of kubernetes PersistentVolume Claim"
+  type         = string
+  default      = "default"
+}
+
+variable "kuberayjob_storageclass_name" {
+  description  = "kubernetes StorageClass name for provisioning persistentvolumeclaims for rayjob"
+  type         = string
+  default      = "azureblob-fuse-premium"
+}
+
+variable "kuberayjob_manifest_path" {
+  description = "Kuberay job filepath"
+  type        = string
+  default     = "../rayjob.yaml"
+}


### PR DESCRIPTION
This commit updates terraform script to do following changes:
- Provision AKS cluster with 2 nodepools
- Deploy kuberay operator through helm

## Purpose
* Updates aks-classic terraform script to provision AKS cluster and install kuberay operator

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
cd aks-automatic
terraform init
terraform plan -out=<path_to_outputfile>
terraform apply
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
- az aks get-credentials --resource-group <rg_name> --name <rg_cluster> --overwrite-existing
- kubectl get po -n kuberay
```
:~$ kubectl get po -n kuberay
NAME                                                    READY   STATUS    RESTARTS   AGE
kuberay-operator-b568bb49f-mwr8z   1/1         Running   0                59s
```