### PR TITLE
fix: update tiny_shakespeare dataset of tune_gp2 script

### DIFF
--- a/sample-tuning-setup/tune_gpt2.py
+++ b/sample-tuning-setup/tune_gpt2.py
@@ -54,12 +54,13 @@ def main(args):
     _ = run_on_every_node(download_model)
 
     print("Loading tiny_shakespeare dataset...")
-    current_dataset = load_dataset("tiny_shakespeare")
+    current_dataset = load_dataset("winglian/tiny-shakespeare")
 
     ray_datasets = {
         "train": ray.data.from_huggingface(current_dataset["train"]),
-        "validation": ray.data.from_huggingface(current_dataset["validation"]),
+        "validation": ray.data.from_huggingface(current_dataset["test"]),
     }
+    print(ray_datasets["train"].take(1))
 
     print("Processing datasets...")
     processed_datasets = {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* This commit updates tiny_shakespeare dataset of tune_gp2 pyscript to `winglian/tiny-shakespeare`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
# Deploy rayjob YAML
kubectl apply -f rayjob.yaml

Output:
rainer_2025-07-03_08-04-09/TorchTrainer_f9279_00000_0_2025-07-03_08-04-10/checkpoint_000001)
(RayTrainWorker pid=794, ip=10.224.0.179) /home/ray/anaconda3/lib/python3.10/site-packages/torch/utils/checkpoint.py:464: UserWarning: torch.utils.checkpoint: the use_reentrant parameter should be passed explicitly. In version 2.4 we will raise an exception if use_reentrant is not passed. use_reentrant=False is recommended, but if you need to preserve the current default behavior, you can pass use_reentrant=True. Refer to docs for more details on the differences between the two variants. [repeated 4x across cluster]
(RayTrainWorker pid=794, ip=10.224.0.179)   warnings.warn( [repeated 4x across cluster]

Training finished iteration 2 at 2025-07-03 08:14:02. Total running time: 9min 52s
╭─────────────────────────────────────────╮
│ Training result                         │
├─────────────────────────────────────────┤
│ checkpoint_dir_name   checkpoint_000001 │
│ time_this_iter_s              238.28394 │
│ time_total_s                  587.11807 │
│ training_iteration                    2 │
│ epoch                               1.5 │
│ learning_rate                        0. │
│ loss                                 0. │
│ step                                  4 │
╰─────────────────────────────────────────╯
Training saved a checkpoint for iteration 2 at: (local)/results/TorchTrainer_2025-07-03_08-04-09/TorchTrainer_f9279_00000_0_2025-07-03_08-04-10/checkpoint_000001
(RayTrainWorker pid=794, ip=10.224.0.179) Checkpoint successfully created at: Checkpoint(filesystem=local, path=/results/TorchTrainer_2025-07-03_08-04-09/TorchTrainer_f9279_00000_0_2025-07-03_08-04-10/checkpoint_000001) [repeated 4x across cluster]
(RayTrainWorker pid=794, ip=10.224.0.179) {'train_runtime': 497.9405, 'train_samples_per_second': 0.643, 'train_steps_per_second': 0.008, 'train_loss': 1.786740243434906, 'epoch': 1.5}
(RayTrainWorker pid=730, ip=10.224.0.158) {'loss': 0.0, 'learning_rate': 0.0, 'epoch': 1.5} [repeated 4x across cluster]

Training completed after 2 iterations at 2025-07-03 08:14:05. Total running time: 9min 54s
2025-07-03 08:14:05,079 INFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/results/TorchTrainer_2025-07-03_08-04-09' in 0.0118s.

(RayTrainWorker pid=730, ip=10.224.0.158) {'train_runtime': 463.1399, 'train_samples_per_second': 0.691, 'train_steps_per_second': 0.009, 'train_loss': 1.786740243434906, 'epoch': 1.5} [repeated 4x across cluster]
2025-07-03 08:14:07,867 SUCC cli.py:63 -- --------------------------------------
2025-07-03 08:14:07,867 SUCC cli.py:64 -- Job 'rayjob-tune-gpt2-xqv25' succeeded
2025-07-03 08:14:07,867 SUCC cli.py:65 -- --------------------------------------

mittas@mittas:~/azstor/kube-ray/aks-ray-sample/sample-tuning-setup$ kubectl get rayjob
NAME               JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                    START TIME             END TIME               AGE
rayjob-tune-gpt2   SUCCEEDED    Complete            rayjob-tune-gpt2-raycluster-cttln   2025-07-03T15:01:23Z   2025-07-03T15:14:10Z   17m
```

## What to Check
Verify that the following are valid

## Other Information
<!-- Add any other helpful information that may be needed here. -->