### PR TITLE
fix: add missing kuberay scrapeconfig to collect metrics

### DIFF
--- a/sample-tuning-setup/kuberay-scrapeconfig.yaml
+++ b/sample-tuning-setup/kuberay-scrapeconfig.yaml
@@ -1,0 +1,29 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  prometheus-config: |-
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+    - job_name: kuberay-metrics
+      honor_labels: true
+      scrape_interval: 15s
+      scheme: http
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - default
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace]
+          action: keep
+          regex: default
+        - source_labels: [__meta_kubernetes_pod_label_ray_io_node_type]
+          action: keep
+          regex: head
+        - source_labels: [__meta_kubernetes_pod_container_port_name]
+          action: keep
+          regex: metrics
+metadata:
+  name: ama-metrics-prometheus-config
+  namespace: kube-system


### PR DESCRIPTION
## Purpose
This PR adds missing scrape config to collect
kuberay metrics and also updates terraform script
to bind AzureMonitoringWorkspace with managed prometheus

## Snippets

<img width="3788" height="1945" alt="Screenshot (7)" src="https://github.com/user-attachments/assets/5f617fd4-1f26-484f-8a70-9d948ee521b4" />
<img width="3728" height="1066" alt="Screenshot (8)" src="https://github.com/user-attachments/assets/e19f3f5d-dde8-48ce-81f2-b821265e1117" />
<img width="3768" height="1811" alt="Screenshot (3)" src="https://github.com/user-attachments/assets/50b8e8dd-c469-4ed5-a6b5-4b810d0765e7" />

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
cd ./sample-tuning-setup/terraform
./deploy.sh

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->