### PR TITLE
Remove old Az features from Terraform configs

### DIFF
--- a/aks-automatic/main.tf
+++ b/aks-automatic/main.tf
@@ -196,7 +196,7 @@ resource "azurerm_dashboard_grafana" "graf" {
   location            = azurerm_resource_group.rg.location
   resource_group_name = azurerm_resource_group.rg.name
   api_key_enabled     = true
-  grafana_major_version = "10"
+  grafana_major_version = "11"
 
   identity {
     type = "SystemAssigned"

--- a/aks-classic/main.tf
+++ b/aks-classic/main.tf
@@ -21,7 +21,6 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   name                             = random_pet.azurerm_kubernetes_cluster_name.id
   resource_group_name              = azurerm_resource_group.rg.name
   dns_prefix                       = random_pet.azurerm_kubernetes_cluster_dns_prefix.id
-  http_application_routing_enabled = true
     
   identity {
     type = "SystemAssigned"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This PR fixes two errors:

**Error 1**

` performing GrafanaCreate: unexpected status 400 (400 Bad Request) with error: GrafanaMajorVersionNotSupported: The requested grafana major version '10' is not valid for sku type Standard. Valid versions: 11`

**Error 2**
`"message": "Client Error: The HTTPApplicationRouting add-on can no longer be enabled on new clusters. Please use the Application Routing Add-on instead: https://aka.ms/app-routing-migration"`


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
